### PR TITLE
Add getEntity helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,27 @@ const user = selectedEntity(usersState) // { id: 1, name: 'Alice' }
                                         // `user` in inferred to be of type `User`
 ```
 
+#### `selectEntity`
+
+Returns an entity of `BaseState` for a given ID, or null if there isn't one.
+
+Example: 
+
+```ts
+const usersState: BaseState<User> = {
+  ids: [1],
+  all: {
+    1: {
+      id: 1,
+      name: 'Alice'
+    }
+  }
+}
+
+const user = selectEntity(usersState, 1) // { id: 1, name: 'Alice' } 
+                                         // `user` is inferred to be of type `User`
+```
+
 #### `isLoaded`
 
 Helper to determine state of a slice of the store that extends `AjaxState` has finishing loading. Basically just checks if the store is _not_ in the initial state (`touched = false`) and `loading` is `false`.

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ const user = selectedEntity(usersState) // { id: 1, name: 'Alice' }
                                         // `user` in inferred to be of type `User`
 ```
 
-#### `selectEntity`
+#### `getEntity`
 
 Returns an entity of `BaseState` for a given ID, or null if there isn't one.
 
@@ -329,7 +329,7 @@ const usersState: BaseState<User> = {
   }
 }
 
-const user = selectEntity(usersState, 1) // { id: 1, name: 'Alice' } 
+const user = getEntity(usersState, 1) // { id: 1, name: 'Alice' } 
                                          // `user` is inferred to be of type `User`
 ```
 

--- a/README.md
+++ b/README.md
@@ -290,28 +290,6 @@ const users = mapEntities(usersState) // [{ id: 1, name: 'Alice' }]
                                       // infers that `users` is of type `User[]`
 ```
 
-#### `selectedEntity`
-
-Returns the currently selected entity of a `SelectableBaseState`, or null if there isn't one.
-
-Example: 
-
-```ts
-const usersState: SelectableBaseState<User> = {
-  selectedId: 1,
-  ids: [1],
-  all: {
-    1: {
-      id: 1,
-      name: 'Alice'
-    }
-  }
-}
-
-const user = selectedEntity(usersState) // { id: 1, name: 'Alice' } 
-                                        // `user` in inferred to be of type `User`
-```
-
 #### `getEntity`
 
 Returns an entity of `BaseState` for a given ID, or null if there isn't one.
@@ -332,6 +310,27 @@ const usersState: BaseState<User> = {
 const user = getEntity(usersState, 1) // { id: 1, name: 'Alice' } 
                                          // `user` is inferred to be of type `User`
 ```
+
+#### `selectedEntity`
+
+Returns the currently selected entity of a `SelectableBaseState`, or null if there isn't one.
+
+Example: 
+
+```ts
+const usersState: SelectableBaseState<User> = {
+  selectedId: 1,
+  ids: [1],
+  all: {
+    1: {
+      id: 1,
+      name: 'Alice'
+    }
+  }
+}
+
+const user = selectedEntity(usersState) // { id: 1, name: 'Alice' } 
+                                        // `user` in inferred to be of type `User`
 
 #### `isLoaded`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,9 @@ import {
   isLoading,
   isReady,
   hasError,
+  getEntity,
   mapEntities,
   selectedEntity,
-  selectEntity,
 } from './selectors'
 
 import {
@@ -37,9 +37,9 @@ export {
   isLoading,
   isReady,
   hasError,
+  getEntity,
   mapEntities,
   selectedEntity,
-  selectEntity,
 
   baseState,
   selectableBaseState,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   hasError,
   mapEntities,
   selectedEntity,
+  selectEntity,
 } from './selectors'
 
 import {
@@ -38,6 +39,7 @@ export {
   hasError,
   mapEntities,
   selectedEntity,
+  selectEntity,
 
   baseState,
   selectableBaseState,

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,11 +1,11 @@
 import { SelectableBaseState, AjaxState, BaseState } from './types'
 
-function selectedEntity<T>(state: SelectableBaseState<T>): T | null {
-  return selectEntity(state, state.selectedId)
+function getEntity<T>(state: BaseState<T>, id: string | number): T | null {
+  return state.all[id] || null
 }
 
-function selectEntity<T>(state: BaseState<T>, id: string | number): T | null {
-  return state.all[id] || null
+function selectedEntity<T>(state: SelectableBaseState<T>): T | null {
+  return getEntity(state, state.selectedId)
 }
 
 function mapEntities<T>(state: BaseState<T>): T[] {
@@ -30,7 +30,7 @@ function hasError<T>(state: AjaxState<T>): boolean {
 
 export {
   selectedEntity,
-  selectEntity,
+  getEntity,
   mapEntities,
   isReady,
   isLoaded,

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -4,7 +4,7 @@ function selectedEntity<T>(state: SelectableBaseState<T>): T | null {
   return selectEntity(state, state.selectedId)
 }
 
-function selectEntity<T>(state: BaseState<T>, id: any): T | null {
+function selectEntity<T>(state: BaseState<T>, id: string | number): T | null {
   return state.all[id] || null
 }
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -28,7 +28,6 @@ function hasError<T>(state: AjaxState<T>): boolean {
   return !state.loading && state.touched && state.errors.length > 0
 }
 
-
 export {
   selectedEntity,
   selectEntity,

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,11 +1,7 @@
 import { SelectableBaseState, AjaxState, BaseState } from './types'
 
 function selectedEntity<T>(state: SelectableBaseState<T>): T | null {
-  if (!state.selectedId) {
-    return null
-  }
-
-  return state.all[state.selectedId]
+  return selectEntity(state, state.selectedId)
 }
 
 function selectEntity<T>(state: BaseState<T>, id: any): T | null {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -8,6 +8,10 @@ function selectedEntity<T>(state: SelectableBaseState<T>): T | null {
   return state.all[state.selectedId]
 }
 
+function selectEntity<T>(state: BaseState<T>, id: any): T | null {
+  return state.all[id] || null
+}
+
 function mapEntities<T>(state: BaseState<T>): T[] {
   return state.ids.map(id => state.all[id])
 }
@@ -31,6 +35,7 @@ function hasError<T>(state: AjaxState<T>): boolean {
 
 export {
   selectedEntity,
+  selectEntity,
   mapEntities,
   isReady,
   isLoaded,

--- a/tests/selectors.spec.ts
+++ b/tests/selectors.spec.ts
@@ -1,6 +1,8 @@
 import {
   AjaxBaseState,
   ajaxBaseState,
+  BaseState,
+  baseState,
   selectableBaseState,
   SelectableBaseState,
   isLoading,
@@ -8,8 +10,9 @@ import {
   isReady,
   hasError,
   selectedEntity,
+  selectEntity
 } from '../src';
- 
+
 describe('selectedEntity', () => {
   const initialState: SelectableBaseState<any> = {
     ...selectableBaseState(),
@@ -28,6 +31,26 @@ describe('selectedEntity', () => {
     expect(actual).toStrictEqual({ key: 'value' })
   })
 })
+
+describe('selectEntity', () => {
+  const initialState: BaseState<any> = {
+    ...baseState(),
+    ids: [ 1 ],
+    all: { 1: { key: 'value' } },
+  }
+
+  it('returns null, because no ID was given', () => {
+    const actual = selectEntity(initialState, null)
+    expect(actual).toBe(null)
+  })
+
+  it('returns the object in the store with the given ID', () => {
+    const state: BaseState<any> = { ...initialState }
+    const actual = selectEntity(state, 1)
+    expect(actual).toStrictEqual({ key: 'value' })
+  })
+})
+ 
 
 describe('isLoading', () => {
   it('is not loading by default', () => {

--- a/tests/selectors.spec.ts
+++ b/tests/selectors.spec.ts
@@ -9,10 +9,29 @@ import {
   isLoaded,
   isReady,
   hasError,
+  getEntity,
   mapEntities,
   selectedEntity,
-  selectEntity
 } from '../src';
+
+describe('getEntity', () => {
+  const initialState: BaseState<any> = {
+    ...baseState(),
+    ids: [ 1 ],
+    all: { 1: { key: 'value' } },
+  }
+
+  it('returns null, because no ID was given', () => {
+    const actual = getEntity(initialState, null)
+    expect(actual).toBe(null)
+  })
+
+  it('returns the object in the store with the given ID', () => {
+    const state: BaseState<any> = { ...initialState }
+    const actual = getEntity(state, 1)
+    expect(actual).toStrictEqual({ key: 'value' })
+  })
+})
 
 describe('mapEntities', () => {
   it('returns empty array, because the store is empty', () => {
@@ -57,26 +76,6 @@ describe('selectedEntity', () => {
     expect(actual).toStrictEqual({ key: 'value' })
   })
 })
-
-describe('selectEntity', () => {
-  const initialState: BaseState<any> = {
-    ...baseState(),
-    ids: [ 1 ],
-    all: { 1: { key: 'value' } },
-  }
-
-  it('returns null, because no ID was given', () => {
-    const actual = selectEntity(initialState, null)
-    expect(actual).toBe(null)
-  })
-
-  it('returns the object in the store with the given ID', () => {
-    const state: BaseState<any> = { ...initialState }
-    const actual = selectEntity(state, 1)
-    expect(actual).toStrictEqual({ key: 'value' })
-  })
-})
- 
 
 describe('isLoading', () => {
   it('is not loading by default', () => {


### PR DESCRIPTION
Adds `selectEntity` helper method to handle retrieving a record from the state for a given `id`.

This functionality provides developers a predefined way for retrieving records. This both compliments `mapEntities` and simplifies the internal logic of `selectedEntity`.

**Example:**
```ts
const usersState: BaseState<User> = {
  ids: [1],
  all: {
    1: {
      id: 1,
      name: 'Alice'
    }
  }
}

const user = selectEntity(usersState, 1) // { id: 1, name: 'Alice' } 
                                         // `user` is inferred to be of type `User`
```